### PR TITLE
Refactor Event Instance & Improve Auto-initialization

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,19 +1,19 @@
 #config.py
 
+AVAILABLE_PLATFORMS = ["windows", "macos", "linuxbsd"]
+
 def can_build(env, platform):
-    return True
+    return platform in AVAILABLE_PLATFORMS
 
 def configure(env):
     if env["platform"] == "windows":
-        # Mostly VisualStudio
-        if env["CC"] == "cl":
-            if env["arch"]=="x86":
-                env.Append(LINKFLAGS=["fmodL.dll", "fmodstudioL.dll"])
-                env.Append(LIBPATH=["#modules/fmod_gd4/api/core/lib/x86/", "#modules/fmod_gd4/api/studio/lib/x86/"])
-            else: # 64 bit
-                env.Append(LINKFLAGS=["fmodL_vc.lib", "fmodstudioL_vc.lib"])
-                env.Append(LIBPATH=["#modules/fmod_gd4/api/core/lib/x64/", "#modules/fmod_gd4/api/studio/lib/x64/"])
-    elif env["platform"] == "osx":
+        if env["arch"]=="x86":
+            env.Append(LINKFLAGS=["fmodL.dll", "fmodstudioL.dll"])
+            env.Append(LIBPATH=["#modules/fmod_gd4/api/core/lib/x86/", "#modules/fmod_gd4/api/studio/lib/x86/"])
+        else: # 64 bit
+            env.Append(LINKFLAGS=["fmodL_vc.lib", "fmodstudioL_vc.lib"])
+            env.Append(LIBPATH=["#modules/fmod_gd4/api/core/lib/x64/", "#modules/fmod_gd4/api/studio/lib/x64/"])
+    elif env["platform"] == "macos":
         env.Append(
             LIBPATH=["#modules/fmod_gd4/api/core/lib/", "#modules/fmod_gd4/api/studio/lib/"])
         env.Append(LIBS=["fmodL", "fmodstudioL"])

--- a/doc_classes/FmodEventInstance.xml
+++ b/doc_classes/FmodEventInstance.xml
@@ -1,83 +1,114 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="FmodEventInstance" inherits="Node" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="FmodEventInstance" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>
+	A wrapper class for the [url=https://www.fmod.com/docs/2.01/api/studio-api-eventinstance.html]FMOD Studio Event Instance[/url].
+	From the [url=https://www.fmod.com/docs/2.01/api/studio-guide.html#playing-events]FMOD Studio API Guide[/url]:
+	"An event is an instanceable unit of sound content that can be triggered, controlled and stopped from game code. Everything that produces a sound in a game should have a corresponding event."
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="create" qualifiers="static">
+			<return type="FmodEventInstance" />
+			<param index="0" name="event_path" type="String" />
+			<description>
+			Creates and initializes an [FmodEventInstance].
+			</description>
+		</method>
 		<method name="get_parameter">
 			<return type="float" />
-			<argument index="0" name="arg0" type="String" />
+			<param index="0" name="_unnamed_arg0" type="String" />
 			<description>
+				Excerpt from the [url=https://www.fmod.com/docs/2.00/api/studio-api-eventinstance.html#studio_eventinstance_getparameterbyname]FMOD Documentation[/url]:
+				"Automatic parameters always return value as 0 since they can never have their value set from the public API.
+
+				[Returned value] is the final value of the parameter after applying adjustments due to automation, modulation, seek speed, and parameter velocity to value. This is calculated asynchronously when the Studio system updates."
 			</description>
 		</method>
 		<method name="get_playback_state">
 			<return type="int" enum="FmodEventInstance.PlaybackState" />
 			<description>
+				Excerpt from the [url=https://www.fmod.com/docs/2.00/api/studio-api-eventinstance.html#studio_eventinstance_getplaybackstate]FMOD Documentation[/url]:
+				"You can poll this function to track the playback state of an event instance.
+
+				If the instance is invalid, then the state will be set to [[constant FmodEventInstance.STOPPED]]."
+			</description>
+		</method>
+		<method name="initialize">
+			<return type="int" enum="Error" />
+			<param index="0" name="event_path" type="String" />
+			<description>
+			Initializes the event instance with the [param event_path] provided. Event instances cannot be initialzed multiple times.
 			</description>
 		</method>
 		<method name="pause">
 			<return type="void" />
 			<description>
-			</description>
-		</method>
-		<method name="perform_release">
-			<return type="void" />
-			<description>
+				Pauses the event instance.
 			</description>
 		</method>
 		<method name="play">
 			<return type="void" />
 			<description>
-			</description>
-		</method>
-		<method name="release_event">
-			<return type="void" />
-			<description>
+				Starts playback of the event instance. See the [url=https://www.fmod.com/docs/2.00/api/studio-api-eventinstance.html#studio_eventinstance_start]FMOD Documentation[/url].
+
+				If the event instance is paused, this will instead resume playback.
 			</description>
 		</method>
 		<method name="set_parameter">
 			<return type="void" />
-			<argument index="0" name="name" type="String" />
-			<argument index="1" name="value" type="float" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="value" type="float" />
 			<description>
+				Sets a parameter on the event instance by name.
+				If the specified parameter is an automatic parameter or doesn't exist, the method will print an error.
 			</description>
 		</method>
 		<method name="stop">
 			<return type="void" />
-			<argument index="0" name="stop_immediately" type="bool" />
+			<param index="0" name="stop_immediately" type="bool" />
 			<description>
+				Stops the event instance.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="event_path" type="String" setter="set_event_path" getter="get_event_path" default="&quot;&quot;">
+			The path this instance will play.
+			[b]Note:[/b] This property is Read Only. It's only set when the event is initialized.
 		</member>
 	</members>
 	<signals>
 		<signal name="event_beat">
 			<description>
+				Called when the timeline hits a beat in a tempo section.
 			</description>
 		</signal>
 		<signal name="event_started">
 			<description>
+				Called when the event is played.
 			</description>
 		</signal>
 		<signal name="event_stopped">
 			<description>
+				Called when the event has stopped.
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="PLAYING" value="0" enum="PlaybackState">
+			The event is playing.
 		</constant>
 		<constant name="PAUSED" value="1" enum="PlaybackState">
+			The event is paused.
 		</constant>
 		<constant name="STOPPING" value="2" enum="PlaybackState">
+			The event is stopping. (Fading out, etc)
 		</constant>
 		<constant name="STOPPED" value="3" enum="PlaybackState">
+			Not playing.
 		</constant>
 	</constants>
 </class>

--- a/doc_classes/FmodManager.xml
+++ b/doc_classes/FmodManager.xml
@@ -3,96 +3,111 @@
 	<brief_description>
 	</brief_description>
 	<description>
+	A wrapper class for the [url=https://www.fmod.com/docs/2.01/api/studio-api-system.html]FMOD Studio System[/url].
+	Must be initialized before FMOD can be used.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="create_event_instance">
 			<return type="FmodEventInstance" />
-			<argument index="0" name="event_path" type="String" />
-			<argument index="1" name="autoplay" type="bool" />
-			<argument index="2" name="one_shot" type="bool" />
+			<param index="0" name="event_path" type="String" />
 			<description>
-				Create an FMOD Studio Event Instance. See [url="https://www.fmod.com/resources/documentation-api?version=2.02&amp;page=studio-api-eventinstance.html"]FMOD Docs[/url]
+				Create a [FmodEventInstance] from the [param event_path] provided.
 			</description>
 		</method>
-		<method name="get_events">
-			<return type="Array" />
+		<method name="get_global_parameter">
+			<return type="float" />
+			<param index="0" name="param_name" type="String" />
 			<description>
+				Excerpt from the [url=https://www.fmod.com/docs/2.00/api/studio-api-system.html#studio_system_getparameterbyname]FMOD Documentation[/url]:
+				"[Return value] is the final value of the parameter after applying adjustments due to automation, modulation, seek speed, and parameter velocity to value. This is calculated asynchronously when the Studio system updates."
 			</description>
 		</method>
 		<method name="get_vca">
 			<return type="FmodVCA" />
-			<argument index="0" name="vca_path" type="String" />
+			<param index="0" name="vca_path" type="String" />
 			<description>
-				Get an FMOD VCA. See [url="https://www.fmod.com/resources/documentation-api?version=2.02&amp;page=studio-api-vca.html"]FMOD Docs[/url]
+				Excerpt from the [url=https://www.fmod.com/docs/2.01/api/studio-api-system.html#studio_system_getvca]FMOD Documentation[/url]:
+				"This function allows you to retrieve a handle for any VCA in the global mixer.
+
+				path may be a path, such as vca:/MyVCA, or an ID string, such as {d9982c58-a056-4e6c-b8e3-883854b4bffb}.
+
+				Note that path lookups will only succeed if the strings bank has been loaded."
 			</description>
 		</method>
 		<method name="initialize">
 			<return type="int" enum="Error" />
-			<argument index="0" name="max_channels" type="int" />
-			<argument index="1" name="studio_flags" type="int" enum="FmodManager.InitFlags" />
+			<param index="0" name="init_flags" type="int" enum="FmodManager.InitFlags" />
+			<param index="1" name="max_channels" type="int" />
 			<description>
-				Initialize the FMOD Studio System. See [url="https://www.fmod.com/resources/documentation-api?version=2.02&amp;page=studio-api-system.html"]FMOD Docs[/url]
+				Initializes the FMOD Studio system. [param max_channels] is the maximum number of channels the FMOD Sound System should use.
 			</description>
 		</method>
 		<method name="load_bank">
 			<return type="int" enum="Error" />
-			<argument index="0" name="path_relative_to_project_root" type="String" />
-			<argument index="1" name="load_flags" type="int" enum="FmodManager.BankLoadFlags" />
+			<param index="0" name="path_relative_to_project_root" type="String" />
+			<param index="1" name="load_flags" type="int" enum="FmodManager.BankLoadFlags" />
 			<description>
-				Load a bank. The path specified is relative to your project root. For example: If my banks are in res://fmod_banks/. I would input "fmod_banks/Master.bank" to load the Master bank.
-			</description>
-		</method>
-		<method name="oneshot">
-			<return type="FmodEventInstance" />
-			<argument index="0" name="event_path" type="String" />
-			<argument index="1" name="autoplay" type="bool" />
-			<description>
-				Create a FmodEventInstance that will be freed after it stops playing. See [method create_event_instance]
+				Loads an FMOD Bank into the Studio system.
+				[b]Note:[/b] Path provided must be relative to project root.
+				Example: A bank located at [code]res://banks/Music.bank[/code] will be loaded with [code]Fmod.load("./banks/Music.bank", NORMAL_LOAD)[/code].
 			</description>
 		</method>
 		<method name="play">
 			<return type="FmodEventInstance" />
-			<argument index="0" name="event_path" type="String" />
+			<param index="0" name="event_path" type="String" />
 			<description>
-				Convinience method for ease of use, alias for [method oneshot].
+				Creates an [FmodEventInstance] and immediately plays it.
 			</description>
 		</method>
 		<method name="randomize_seed">
 			<return type="void" />
 			<description>
-				Internal function to make sure randomization is done right.
+				Randomizes FMOD's random number generator for randome events.
+				This is called automatically when FMOD is initialized.
+				See the [url=https://www.fmod.com/docs/2.01/api/core-api-system.html#fmod_advancedsettings]FMOD Documentation[/url].
 			</description>
 		</method>
-		<method name="set_events">
+		<method name="set_global_parameter">
 			<return type="void" />
-			<argument index="0" name="a" type="Array" />
+			<param index="0" name="param_name" type="String" />
+			<param index="1" name="new_value" type="float" />
 			<description>
-				Internal.
+				Sets a global parameter's value.
 			</description>
 		</method>
 	</methods>
 	<constants>
 		<constant name="NORMAL" value="0" enum="InitFlags">
+			Use defaults for all initialization options.
 		</constant>
 		<constant name="LIVE_UPDATE" value="1" enum="InitFlags">
+			Enable live update.
 		</constant>
 		<constant name="ALLOW_MISSING_PLUGINS" value="2" enum="InitFlags">
+			Load banks even if they reference plugins that have not been loaded.
 		</constant>
 		<constant name="SYNCHRONOUS_UPDATE" value="3" enum="InitFlags">
+			Disable asynchronous processing and perform all processing on the calling thread instead.
 		</constant>
 		<constant name="DEFERRED_CALLBACKS" value="4" enum="InitFlags">
+			Defer timeline callbacks until the main update.
 		</constant>
 		<constant name="LOAD_FROM_UPDATE" value="5" enum="InitFlags">
+			No additional threads are created for bank and resource loading. Loading is done when the FmodManager recieves [constant Node.NOTIFICATION_PROCESS]. See [url=https://docs.godotengine.org/en/latest/tutorials/scripting/idle_and_physics_processing.html]the Godot Docs[/url].
 		</constant>
 		<constant name="MEMORY_TRACKING" value="6" enum="InitFlags">
+			Enables detailed memory usage statistics. This can help when using a C++ Debugger.
 		</constant>
 		<constant name="NORMAL_LOAD" value="0" enum="BankLoadFlags">
+			Normal bank loading.
 		</constant>
 		<constant name="NONBLOCKING" value="1" enum="BankLoadFlags">
+			Bank loading is asynchronous instead of blocking until the load is finished.
 		</constant>
 		<constant name="DECOMPRESS_SAMPLES" value="2" enum="BankLoadFlags">
+			Force samples to be decompressed when loaded.
 		</constant>
 		<constant name="UNENCRYPTED" value="3" enum="BankLoadFlags">
 		</constant>

--- a/doc_classes/FmodVCA.xml
+++ b/doc_classes/FmodVCA.xml
@@ -3,13 +3,16 @@
 	<brief_description>
 	</brief_description>
 	<description>
+	A handle to an FMOD VCA.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="path" type="String" setter="" getter="get_path" default="&quot;&quot;">
+			The FMOD path of this VCA.
 		</member>
 		<member name="volume" type="float" setter="set_volume" getter="get_volume" default="-1.0">
+			The volume of this VCA. See the [url=https://www.fmod.com/docs/2.01/api/studio-api-vca.html#studio_vca_setvolume]FMOD Documentation[/url].
 		</member>
 	</members>
 </class>

--- a/gd_fmod_event_instance.cpp
+++ b/gd_fmod_event_instance.cpp
@@ -8,27 +8,20 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include "gd_fmod_gd4.h"
 #include "gd_fmod_event_instance.h"
 
-String FmodEventInstance::get_event_path() {
-    return event_path;
-}
-
-void FmodEventInstance::set_event_path(String path) {
-
-}
-
 void FmodEventInstance::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("get_playback_state"), &FmodEventInstance::get_playback_state);
-    ClassDB::bind_method(D_METHOD("stop", "stop_immediately"), &FmodEventInstance::stop);
 	ClassDB::bind_method(D_METHOD("play"), &FmodEventInstance::play);
 	ClassDB::bind_method(D_METHOD("pause"), &FmodEventInstance::pause);
-    ClassDB::bind_method(D_METHOD("release_event"), &FmodEventInstance::release_event);
-    ClassDB::bind_method(D_METHOD("perform_release"), &FmodEventInstance::perform_release);
+    ClassDB::bind_method(D_METHOD("stop", "stop_immediately"), &FmodEventInstance::stop);
+    ClassDB::bind_method(D_METHOD("get_playback_state"), &FmodEventInstance::get_playback_state);
 	ClassDB::bind_method(D_METHOD("get_event_path"), &FmodEventInstance::get_event_path);
 	ClassDB::bind_method(D_METHOD("set_event_path", "path"), &FmodEventInstance::set_event_path);
 	ClassDB::bind_method(D_METHOD("get_parameter"), &FmodEventInstance::get_parameter);
     ClassDB::bind_method(D_METHOD("set_parameter", "name", "value"), &FmodEventInstance::set_parameter);
+    ClassDB::bind_method(D_METHOD("initialize", "event_path"), &FmodEventInstance::initialize);
+    ClassDB::bind_static_method("FmodEventInstance", D_METHOD("create", "event_path"), &FmodEventInstance::create);
 
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "event_path"), "set_event_path", "get_event_path");
 
@@ -37,59 +30,59 @@ void FmodEventInstance::_bind_methods() {
     BIND_ENUM_CONSTANT(STOPPING);
     BIND_ENUM_CONSTANT(STOPPED);
 
-
 	ADD_SIGNAL(MethodInfo("event_started"));
 	ADD_SIGNAL(MethodInfo("event_stopped"));
 	ADD_SIGNAL(MethodInfo("event_beat"));
 
 }
 
-void FmodEventInstance::set_callback() {
-	_event_instance->setUserData(&current_callback);
-	_event_instance->setCallback(FmodEventInstance::fmod_callback, FMOD_STUDIO_EVENT_CALLBACK_ALL);
+String FmodEventInstance::get_event_path() {
+    return event_path;
 }
 
-FMOD_RESULT F_CALLBACK FmodEventInstance::fmod_callback(FMOD_STUDIO_EVENT_CALLBACK_TYPE type, FMOD_STUDIO_EVENTINSTANCE *event, void *parameters) {
-	FMOD::Studio::EventInstance *instance = (FMOD::Studio::EventInstance *)event;
-	int *e_inst = nullptr;
-
-	instance->getUserData((void **)&e_inst);
-    *e_inst = type;
-	return FMOD_OK;
+void FmodEventInstance::set_event_path(const String path) {
 }
 
+const bool FmodEventInstance::is_instance_valid() {
+	return inner_event_instance != nullptr && inner_event_instance->isValid();
+}
+
+// Playback state
 void FmodEventInstance::play() {
-	if(_event_instance == nullptr) {
-		queue_free();
+	if(inner_event_instance == nullptr) {
 		return;
 	}
 	PlaybackState state = get_playback_state();
 	if(state == PAUSED) {
-		_event_instance->setPaused(false);
+		inner_event_instance->setPaused(false);
 		return;
 	}
-	_event_instance->start();
+	inner_event_instance->start();
 }
 
 void FmodEventInstance::pause() {
-	if(_event_instance == nullptr) {
+	if(!is_instance_valid()) {
 		return;
 	}
 	PlaybackState state = get_playback_state();
 	if(state != PAUSED) {
-		_event_instance->setPaused(true);
+		inner_event_instance->setPaused(true);
 	}
 }
 
-FmodEventInstance::PlaybackState FmodEventInstance::get_playback_state() {
-    if(_event_instance == nullptr) {
-		queue_free();
-		return PlaybackState::STOPPED;
-	}
-    FMOD_STUDIO_PLAYBACK_STATE p_state = FMOD_STUDIO_PLAYBACK_STOPPED;
-    _event_instance->getPlaybackState(&p_state);
+void FmodEventInstance::stop(const bool stop_immediately) {
+    if(!is_instance_valid()) {
+		return;
+    }
+    inner_event_instance->stop(stop_immediately ? FMOD_STUDIO_STOP_IMMEDIATE : FMOD_STUDIO_STOP_ALLOWFADEOUT);
+}
 
-    PlaybackState state_to_return = STOPPED;
+FmodEventInstance::PlaybackState FmodEventInstance::get_playback_state() {
+	ERR_FAIL_COND_V_MSG(!is_instance_valid(), PlaybackState::STOPPED, vformat("Could not get playback state. Event instance is invalid. (%s)", event_path));
+    FMOD_STUDIO_PLAYBACK_STATE p_state = FMOD_STUDIO_PLAYBACK_STOPPED;
+    inner_event_instance->getPlaybackState(&p_state);
+
+    PlaybackState state_to_return;
     switch(p_state) {
 		case FMOD_STUDIO_PLAYBACK_PLAYING: {
 			state_to_return = PLAYING;
@@ -100,113 +93,98 @@ FmodEventInstance::PlaybackState FmodEventInstance::get_playback_state() {
         case FMOD_STUDIO_PLAYBACK_STOPPING: {
             state_to_return = STOPPING;
         } break;
-        case FMOD_STUDIO_PLAYBACK_STOPPED: {
+        default: {
             state_to_return = STOPPED;
         } break;
 	}
 	return state_to_return;
 }
 
-void FmodEventInstance::stop(bool stop_immediately) {
-    if(_event_instance == nullptr) {
-		return;
-    }
-    _event_instance->stop(stop_immediately ? FMOD_STUDIO_STOP_IMMEDIATE : FMOD_STUDIO_STOP_ALLOWFADEOUT);
+// Parameters
+void FmodEventInstance::set_parameter(const String p_name, const float p_value) {
+	ERR_FAIL_COND_MSG(!is_instance_valid(), vformat("Event instance invalid. Could not set paramter %s", p_name));
+	FMOD_RESULT result = inner_event_instance->setParameterByName(p_name.utf8(), p_value);
+	ERR_FAIL_COND_MSG(result != FMOD_RESULT::FMOD_OK, vformat("An error occured while setting parameter %s on %s. FMOD_RESULT Error Code: %s", p_name, event_path, static_cast<int>(result)));
 }
 
-void FmodEventInstance::release_event() {
-    perform_release();
-}
-
-void FmodEventInstance::perform_release() {
-    if(_event_instance != nullptr) {
-		if(get_playback_state() != STOPPED) {
-			stop(true);
-		}
-        _event_instance->release();
-    }
-    queue_free();
-}
-
-void FmodEventInstance::set_parameter(String p_name, float p_value) {
-	ERR_FAIL_COND_MSG(_event_instance == nullptr, vformat("Event instance invalid. Could not set paramter %s", p_name));
-	FMOD_RESULT result = _event_instance->setParameterByName(p_name.utf8(), p_value);
-	ERR_FAIL_COND_MSG(result != OK, vformat("An error occured while setting parameter %s on %s. FMOD_RESULT Error Code: %s", p_name, event_path, static_cast<int>(result)));
-}
-
-float FmodEventInstance::get_parameter(String p_name) {
-	ERR_FAIL_COND_V_MSG(_event_instance == nullptr, -1.0, vformat("Event instance invalid. Could not get paramter %s", p_name));
+float FmodEventInstance::get_parameter(const String p_name) {
+	ERR_FAIL_COND_V_MSG(!is_instance_valid(), -1.0, vformat("Event instance invalid. Could not get paramter %s", p_name));
 	float r = 0;
-	FMOD_RESULT result = _event_instance->getParameterByName(p_name.utf8(), 0, &r);
-	ERR_FAIL_COND_V_MSG(result != OK, -1.0, vformat("An error occured while getting parameter %s on %s. FMOD_RESULT Error Code: %s", p_name, event_path, static_cast<int>(result)));
+	FMOD_RESULT result = inner_event_instance->getParameterByName(p_name.utf8(), 0, &r);
+	ERR_FAIL_COND_V_MSG(result != FMOD_RESULT::FMOD_OK, -1.0, vformat("An error occured while getting parameter %s on %s. FMOD_RESULT Error Code: %s", p_name, event_path, static_cast<int>(result)));
 	return r;
 }
 
-void FmodEventInstance::_notification(int p_notification) {
-	if(p_notification == NOTIFICATION_PREDELETE) {
-		if(_event_instance != nullptr) {
-			_event_instance->release();
-		}
+// Callbacks
+void FmodEventInstance::activate_fmod_callback_reciever() {
+	inner_event_instance->setUserData(&current_callback);
+	inner_event_instance->setCallback(FmodEventInstance::fmod_callback, FMOD_STUDIO_EVENT_CALLBACK_ALL);
+}
+
+FMOD_RESULT F_CALLBACK FmodEventInstance::fmod_callback(FMOD_STUDIO_EVENT_CALLBACK_TYPE type, FMOD_STUDIO_EVENTINSTANCE *event, void *parameters) {
+	FMOD::Studio::EventInstance *event_instance = reinterpret_cast<FMOD::Studio::EventInstance *>(event);
+	if (event_instance == nullptr) {
+		return FMOD_ERR_INVALID_HANDLE;
 	}
-	else if(p_notification != NOTIFICATION_INTERNAL_PROCESS) {
+	void *event_user_data = nullptr;
+	event_instance->getUserData(&event_user_data);
+	int *current_callback_ptr = static_cast<int *>(event_user_data);
+	if (current_callback_ptr == nullptr) {
+		return FMOD_ERR_INVALID_HANDLE;
+	}
+	*current_callback_ptr = type;
+	return FMOD_OK;
+}
+
+const void FmodEventInstance::process_current_callback() {
+	if (current_callback == -1) {
 		return;
 	}
-
-	if(current_callback != -1) {
-		switch(current_callback) {
-			case FMOD_STUDIO_EVENT_CALLBACK_STARTED: {
-				emit_signal("event_started");
-			} break;
-			case FMOD_STUDIO_EVENT_CALLBACK_SOUND_STOPPED: {
-				emit_signal("event_stopped");
-				if (one_shot) {
-					perform_release();
-				}
-			} break;
-			case FMOD_STUDIO_EVENT_CALLBACK_TIMELINE_BEAT: {
-				current_beat += 1;
-				emit_signal("event_beat", current_beat);
-			} break;
-		}
+	switch(current_callback) {
+		case FMOD_STUDIO_EVENT_CALLBACK_STARTED: {
+			emit_signal(SNAME("event_started"));
+		} break;
+		case FMOD_STUDIO_EVENT_CALLBACK_SOUND_STOPPED: {
+			emit_signal(SNAME("event_stopped"));
+		} break;
+		case FMOD_STUDIO_EVENT_CALLBACK_TIMELINE_BEAT: {
+			current_beat += 1;
+			emit_signal(SNAME("event_beat"), current_beat);
+		} break;
 	}
 	current_callback = -1;
-	// if(one_shot) {
-	// 	//print_line(vformat("Oneshot", 0));
-	// 	FMOD_STUDIO_PLAYBACK_STATE state = FMOD_STUDIO_PLAYBACK_STOPPED;
-	// 	FMOD_RESULT f = _event_instance->getPlaybackState(&state);
-	// 	if (f == FMOD_OK) {
-	// 		if (state == FMOD_STUDIO_PLAYBACK_STOPPED) {
-	// 			perform_release();
-	// 		}
-	// 	}
-	// 	else {
-	// 		perform_release();
-	// 	}
-	// }
 }
-//
-//bool FmodEventInstance::unreference() {
-//    if(_event_instance != nullptr) {
-//        if (reference_get_count() - 1 <= 0) {
-//            FMOD_STUDIO_PLAYBACK_STATE *state = nullptr;
-//            _event_instance->getPlaybackState(state);
-//            if(*state == FMOD_STUDIO_PLAYBACK_STOPPED) {
-//				print_line("Unreferencing to zero");
-//                return RefCounted::unreference();
-//            }
-//            else {
-//                return false;
-//            }
-//        }
-//        else {
-//            return RefCounted::unreference();
-//        }
-//    }
-//    else {
-//        return RefCounted::unreference();
-//    }
-//}
 
+// Lifetime
 FmodEventInstance::FmodEventInstance() {
-	set_process_internal(true);
+}
+
+FmodEventInstance::~FmodEventInstance() {
+	if(inner_event_instance != nullptr) {
+		inner_event_instance->release();
+	}
+}
+
+Ref<FmodEventInstance> FmodEventInstance::create(const String instance_event_path) {
+	Ref<FmodEventInstance> event_instance = memnew(FmodEventInstance);
+	event_instance->initialize(instance_event_path);
+	return event_instance;
+}
+
+Error FmodEventInstance::initialize(const String instance_event_path) {
+	ERR_FAIL_COND_V_MSG(!FmodManager::get_singleton()->initialized, Error::ERR_UNCONFIGURED, vformat("Could not initialize event instance (%s). Fmod is not initalized!", instance_event_path));
+	ERR_FAIL_COND_V_MSG(is_instance_valid(), Error::ERR_ALREADY_IN_USE, vformat("Attempted to re-initialize a valid event instance! (%s)", instance_event_path));
+	FMOD::Studio::EventDescription *e_desc = nullptr;
+    FMOD_RESULT result = FmodManager::get_singleton()->fmod_system->getEvent(instance_event_path.utf8().get_data(), &e_desc);
+	ERR_FAIL_NULL_V_MSG(e_desc, Error::ERR_QUERY_FAILED, vformat("Could not get EventDescription for: %s. FMOD_RESULT Error Code: %s", instance_event_path, result));
+
+    FMOD::Studio::EventInstance *e_instance = nullptr;
+    e_desc->createInstance(&e_instance);
+	ERR_FAIL_NULL_V_MSG(e_instance, Error::ERR_CANT_CREATE, vformat("Could not create Event Instance for: %s. FMOD_RESULT Error Code: %s", instance_event_path, static_cast<int>(result)));
+
+	this->inner_event_instance = e_instance;
+	this->event_path = instance_event_path;
+	activate_fmod_callback_reciever();
+	FmodManager::get_singleton()->events.append(this);
+	return Error::OK;
 }

--- a/gd_fmod_event_instance.cpp
+++ b/gd_fmod_event_instance.cpp
@@ -170,19 +170,19 @@ void FmodEventInstance::_notification(int p_notification) {
 		}
 	}
 	current_callback = -1;
-	if(one_shot) {
-		//print_line(vformat("Oneshot", 0));
-		FMOD_STUDIO_PLAYBACK_STATE state = FMOD_STUDIO_PLAYBACK_STOPPED;
-		FMOD_RESULT f = _event_instance->getPlaybackState(&state);
-		if (f == FMOD_OK) {
-			if (state == FMOD_STUDIO_PLAYBACK_STOPPED) {
-				perform_release();
-			}
-		}
-		else {
-			perform_release();
-		}
-	}
+	// if(one_shot) {
+	// 	//print_line(vformat("Oneshot", 0));
+	// 	FMOD_STUDIO_PLAYBACK_STATE state = FMOD_STUDIO_PLAYBACK_STOPPED;
+	// 	FMOD_RESULT f = _event_instance->getPlaybackState(&state);
+	// 	if (f == FMOD_OK) {
+	// 		if (state == FMOD_STUDIO_PLAYBACK_STOPPED) {
+	// 			perform_release();
+	// 		}
+	// 	}
+	// 	else {
+	// 		perform_release();
+	// 	}
+	// }
 }
 //
 //bool FmodEventInstance::unreference() {

--- a/gd_fmod_event_instance.h
+++ b/gd_fmod_event_instance.h
@@ -11,57 +11,53 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #ifndef GODOT_FMOD_EVENT_INSTANCE_H
 #define GODOT_FMOD_EVENT_INSTANCE_H
 
-#include "scene/main/node.h"
+#include "core/object/ref_counted.h"
 #include "api/core/inc/fmod.hpp"
 #include "api/studio/inc/fmod_studio.hpp"
 
-class FmodEventInstance : public Node {
-	GDCLASS(FmodEventInstance, Node);
+class FmodManager;
+class FmodEventInstance : public RefCounted {
+	GDCLASS(FmodEventInstance, RefCounted);
 
 protected:
     static void _bind_methods();
-    void _notification(int p_what);
+    FMOD::Studio::EventInstance *inner_event_instance = nullptr;
 
 public:
-    int current_callback = -1;
-    //auto manager;
-    FMOD::Studio::EventInstance *_event_instance = nullptr;
+    const bool is_instance_valid();
+
+    String event_path;
+
+    String get_event_path();
+    void set_event_path(const String path);
+
+    // Playback State
     enum PlaybackState {
 		PLAYING,
 		PAUSED,
         STOPPING,
         STOPPED
     };
-
-    String event_path;
-
-    String get_event_path();
-    void set_event_path(String path);
-
-    PlaybackState get_playback_state();
-	void stop(bool stop_immediately=false);
-	void set_parameter(String p_name, float p_value);
-	float get_parameter(String p_name);
-	void set_callback();
-    void release_event();
 	void play();
 	void pause();
+	void stop(const bool stop_immediately=false);
+    PlaybackState get_playback_state();
 
-	bool one_shot = false;
+    // Parameters
+	void set_parameter(const String p_name, const float p_value);
+	float get_parameter(const String p_name);
 
+    // Callbacks
+    FMOD_STUDIO_EVENT_CALLBACK_TYPE current_callback = -1;
     int current_beat = 0;
-
+	void activate_fmod_callback_reciever();
 	static FMOD_RESULT F_CALLBACK fmod_callback(FMOD_STUDIO_EVENT_CALLBACK_TYPE type, FMOD_STUDIO_EVENTINSTANCE *event, void *parameters);
+    const void process_current_callback();
 
+    Error initialize(const String event_path);
+    static Ref<FmodEventInstance> create(const String event_path);
     FmodEventInstance();
-
-    void perform_release();
-
-    void read_callback();
-
-    int get_signal();
-
-    void set_signal(int t);
+    ~FmodEventInstance();
 };
 
 VARIANT_ENUM_CAST(FmodEventInstance::PlaybackState);

--- a/gd_fmod_gd4.cpp
+++ b/gd_fmod_gd4.cpp
@@ -72,7 +72,6 @@ Error FmodManager::initialize(int max_channels, InitFlags studio_flags) {
     initialized = true;
 	randomize_seed();
 	set_process_internal(true);
-	set_process(true);
     print_line("Initialized FMOD successfully.");
     return OK;
 }
@@ -226,12 +225,6 @@ void FmodManager::_notification(int p_what) {
         case NOTIFICATION_INTERNAL_PROCESS: {
             run_callbacks();
         } break;
-        case NOTIFICATION_PREDELETE: {
-            if(initialized) {
-                f_system->release();
-                memdelete(&f_system);
-            }
-        } break;
     }
 }
 
@@ -247,5 +240,11 @@ FmodManager::FmodManager() {
 			singleton->queue_free();
 			singleton = this;
 		}
+    }
+}
+
+FmodManager::~FmodManager() {
+    if(initialized) {
+       f_system->release();
     }
 }

--- a/gd_fmod_gd4.h
+++ b/gd_fmod_gd4.h
@@ -73,6 +73,7 @@ public:
     void randomize_seed();
 
     FmodManager();
+    ~FmodManager();
 };
 
 VARIANT_ENUM_CAST(FmodManager::InitFlags);

--- a/gd_fmod_gd4.h
+++ b/gd_fmod_gd4.h
@@ -38,6 +38,8 @@ public:
         LOAD_FROM_UPDATE,
         MEMORY_TRACKING
     };
+	const String INIT_FLAGS_PROPERTY_HINT = "NORMAL,LIVE_UPDATE,ALLOW_MISSING_PLUGINS,SYNCHRONOUS_UPDATE,DEFERRED_CALLBACKS,LOAD_FROM_UPDATE,MEMORY_TRACKING";
+
     enum BankLoadFlags {
         NORMAL_LOAD,
         NONBLOCKING,
@@ -47,28 +49,26 @@ public:
 
     static FmodManager* get_singleton();
 
-    FMOD::Studio::System *f_system;
+    FMOD::Studio::System *fmod_system;
 
-    VMap<String, FMOD::Studio::Bank*> loaded_banks;
-    Array events = Array();
-
-    Array get_events();
-    void set_events(Array a);
+    HashMap<String, FMOD::Studio::Bank*> loaded_banks;
+    Vector<FmodEventInstance *> events = Vector<FmodEventInstance *>();
 
 	void set_global_parameter(String p_name, float p_value);
 	float get_global_parameter(String p_name);
 
     bool initialized = false;
+	bool added_to_tree = false;
 
-    void run_callbacks();
     void _notification(int p_what);
-    Error initialize(int max_channels, InitFlags studio_flags);
+    Error initialize(InitFlags studio_flags, int max_channels);
+	void auto_initialize(InitFlags init_flags, TypedArray<String> banks_to_load, int max_channels);
+    void add_to_tree();
     Error load_bank(String path_relative_to_project_root, BankLoadFlags flags);
 
-	FmodEventInstance* create_event_instance(String event_path, bool autoplay = false, bool one_shot = false);
-    FmodVCA* get_vca(String vca_path);
-	FmodEventInstance* oneshot(String event_path, bool autoplay = false);
-    FmodEventInstance* play(String event_path); // Convenience function for ease of use, alias for oneshot(event_path, true)
+	Ref<FmodEventInstance> create_event_instance(String event_path);
+    Ref<FmodVCA> get_vca(String vca_path);
+    Ref<FmodEventInstance> play(String event_path);
 
     void randomize_seed();
 

--- a/gd_fmod_vca.cpp
+++ b/gd_fmod_vca.cpp
@@ -43,3 +43,7 @@ void FmodVCA::_bind_methods() {
 }
 
 FmodVCA::FmodVCA() {}
+
+FmodVCA::~FmodVCA() {
+}
+

--- a/gd_fmod_vca.h
+++ b/gd_fmod_vca.h
@@ -28,6 +28,7 @@ public:
     String path;
     String get_path();
     FmodVCA();
+    ~FmodVCA();
 
 };
 

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -14,8 +14,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "core/config/project_settings.h"
 
-static FmodManager* FmodManagerPtr = NULL;
-
 void initialize_fmod_gd4_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		// Register classes
@@ -23,31 +21,10 @@ void initialize_fmod_gd4_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(FmodEventInstance);
 		GDREGISTER_CLASS(FmodVCA);
 		// Singleton
-		FmodManagerPtr = memnew(FmodManager);
 		Engine::get_singleton()->add_singleton(Engine::Singleton("Fmod", FmodManager::get_singleton()));
-
-		// Add FMOD settings
-		if (Engine::get_singleton()->is_editor_hint()) {
-			if (!ProjectSettings::get_singleton()->has_setting("fmod/config/auto_initialize")) {
-				GLOBAL_DEF("fmod/config/auto_initialize", true);
-				GLOBAL_DEF("fmod/config/max_channels", 1024);
-				GLOBAL_DEF("fmod/config/initialization_mode", 0);
-				ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::INT, "fmod/config/initialization_mode", PROPERTY_HINT_ENUM, "NORMAL,LIVE_UPDATE,ALLOW_MISSING_PLUGINS,SYNCHRONOUS_UPDATE,DEFERRED_CALLBACKS,LOAD_FROM_UPDATE,MEMORY_TRACKING"));
-				PackedStringArray init_banks = PackedStringArray();
-				init_banks.append("Master");
-				init_banks.append("Master.strings");
-				GLOBAL_DEF("fmod/config/banks_to_load", init_banks);
-				//ProjectSettings::get_singleton()->set_initial_value()
-				print_line(ProjectSettings::get_singleton()->save());
-				// ProjectSettings::get_singleton()->set_initial_value("fmod/config/auto_initialize", true);
-				// ProjectSettings::get_singleton()->set_initial_value("fmod/config/max_channels", 1024);
-				// ProjectSettings::get_singleton()->set_initial_value("fmod/config/initialization_mode", 0);
-				// ProjectSettings::get_singleton()->set_initial_value("fmod/config/banks_to_load", init_banks);
-			}
-		}
 	}
 }
 
 void uninitialize_fmod_gd4_module(ModuleInitializationLevel p_level) {
-  memdelete(FmodManagerPtr);
+	memdelete(FmodManager::get_singleton());
 }


### PR DESCRIPTION
`FmodEventInstance` now uses `RefCounted` instead of Node. This allows for the instance's internal fmod representation to be automatically released when no longer needed. Because of this change, `FmodManager::oneshot` was removed, since the event instance will automatically call `release` when the instance goes out of scope. 

Removed bloat and unnecessary methods. Rewrote auto-initialization and singleton handling.

TODO:
- [x] Update all documentation
- [x] Test